### PR TITLE
Cloudinary URLのオプションテキストを修正

### DIFF
--- a/content/blog/cloudinary-dynamic-ogp-image/index.md
+++ b/content/blog/cloudinary-dynamic-ogp-image/index.md
@@ -102,7 +102,7 @@ l_text:フォント種類_フォントサイズ_ウェイト:配置するテキ�
 
 まとめると次のようになる。これを画像のURLの中に追加する。
 ```html:title=こんな指定にする
-_text:Sawarabi%20Gothic_45:テキスト,co_rgb:FFF,w_500,c_fit
+l_text:Sawarabi%20Gothic_45:テキスト,co_rgb:FFF,w_500,c_fit
 ```
 
 ## 完全なURL


### PR DESCRIPTION
`l`が抜けていた箇所があったので修正を作成しました。

```
_text:Sawarabi%20Gothic_45:テキスト,co_rgb:FFF,w_500,c_fit
```